### PR TITLE
Add floating bottom navigation bar

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -43,7 +43,7 @@ header {
     left: 0;
 }
 
-header nav {
+header .nav {
     /*background-color: rgba(255, 255, 255, 0.75);
     -webkit-backdrop-filter: blur(40px)!important;
     backdrop-filter: blur(40px);*/
@@ -436,6 +436,70 @@ footer {
     font-size: 12px;
     padding-bottom: 16px;
     margin-top: 1rem;
+}
+
+/* floating bottom nav */
+.floating-nav {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: fit-content;
+    padding: 10px;
+    border-radius: 100px;
+    background-color: rgba(255, 255, 255, 0.6);
+    -webkit-backdrop-filter: blur(20px);
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 8px 32px rgba(70, 70, 86, 0.1);
+}
+
+.floating-nav-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    color: #707187;
+    font-size: 1.25rem;
+    text-decoration: none;
+    transition: color 0.25s ease;
+}
+
+.floating-nav-item:hover {
+    color: #464656;
+}
+
+.floating-nav-tooltip {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translate(-50%, 4px);
+    background-color: #464656;
+    color: #fff;
+    padding: 4px 10px;
+    border-radius: 8px;
+    font-family: "Inter", "Helvetica", sans-serif;
+    font-size: 12px;
+    white-space: nowrap;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+        opacity 0.25s ease,
+        transform 0.25s ease;
+}
+
+.floating-nav-item:hover .floating-nav-tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0);
 }
 
 /* media query */

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         <div class="container">
             <!-- nav -->
             <header class="fade-up">
-                <nav>
+                <div class="nav">
                     <a href="index.html">
                         <div class="header-pic">
                             <img src="images/mypic2.webp" alt="Home" />
@@ -30,18 +30,20 @@
                             Digital & Brand Experience Designer
                         </span>
                     </div>
-                </nav>
+                </div>
             </header>
 
             <!-- about section -->
             <section class="about fade-up delay-1">
-                
                 <div>
                     A design generalist with a focus on digital experiences — I
                     design with intention and enjoy working on projects that
                     make me feel like I can move mountains by pushing pixels.
                     Currently designing for skin health & beauty brands at
                     Kenvue.<br />
+                    <!-- <a href="mailto:nellawongly@gmail.com"
+                        ><button>Email</button></a
+                    > -->
 
                     <!-- spacing -->
                     <div id="horizontal-spacing-l"></div>
@@ -145,7 +147,24 @@
             <footer class="fade-up delay-4">
                 © <span id="year"></span> Nella Wong
             </footer>
-            <script src="include/script.js"></script>
         </div>
+
+        <!-- floating bottom nav -->
+        <nav class="floating-nav fade-up">
+            <a href="#" class="floating-nav-item">
+                <iconify-icon icon="carbon:home"></iconify-icon>
+                <span class="floating-nav-tooltip">Home</span>
+            </a>
+            <a href="#" class="floating-nav-item">
+                <iconify-icon icon="carbon:user"></iconify-icon>
+                <span class="floating-nav-tooltip">About</span>
+            </a>
+            <a href="#" class="floating-nav-item">
+                <iconify-icon icon="carbon:email"></iconify-icon>
+                <span class="floating-nav-tooltip">Contact</span>
+            </a>
+        </nav>
+
+        <script src="include/script.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- New fixed, pill-shaped bottom nav (not full width) with 24px gap from the viewport bottom
- Frosted-glass style: semi-transparent white background, `backdrop-filter: blur(20px)`, subtle low-opacity white border
- Three carbon iconify icons (`carbon:home`, `carbon:user`, `carbon:email`), each linking to `#` as a placeholder until the target pages exist
- Icon color shifts on hover; a text label tooltip fades in smoothly above the icon on hover only

## Note
This branch was built directly on top of your current uncommitted working-copy state for `index.html` / `include/style.css` (so the diff also carries a couple of small in-progress tweaks you already had — the `header nav` → `header .nav` change and the re-added mailto comment). Feel free to squash/cherry-pick as you see fit.

## Test plan
- [ ] Open `index.html` locally and confirm the pill nav sits centered at the bottom with 24px clearance
- [ ] Hover each icon: confirm color change + tooltip fade-in above the icon
- [ ] Resize to mobile width to confirm nav stays centered and doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv795gY9xaTz8yvu6FsLG3